### PR TITLE
Fix failing tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: php
 
 php:
-  - 5.6
   - 7.0
-  - hhvm
 
 sudo: false
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "source": "https://github.com/arubacao/http-basic-auth-guard"
     },
     "require": {
-        "php": ">=5.6.0",
+        "php": ">=7.0.0",
         "illuminate/database": "^5.2",
         "illuminate/support": "^5.2"
     },

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -33,7 +33,7 @@ abstract class AbstractTestCase extends AbstractPackageTestCase
         parent::setUp();
 
         $this->artisan('migrate', [
-            '--realpath' => realpath(__DIR__.'/database/migrations'),
+            '--path' => realpath(__DIR__.'/database/migrations'),
         ]);
 
         $this->withFactories(realpath(__DIR__.'/database/factories'));

--- a/tests/AuthenticationTest.php
+++ b/tests/AuthenticationTest.php
@@ -8,9 +8,9 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-use Illuminate\Auth\Events\Attempting;
 use Illuminate\Auth\Events\Login;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Auth\Events\Attempting;
 
 class AuthenticationTest extends AbstractTestCase
 {

--- a/tests/AuthenticationTest.php
+++ b/tests/AuthenticationTest.php
@@ -46,7 +46,7 @@ class AuthenticationTest extends AbstractTestCase
     public function user_gets_ok_with_correct_credentials_with_auth_middleware()
     {
         $user = factory(User::class)->create([
-            'password' => bcrypt('123456'),
+            'password' => password_hash('123456'),
         ]);
         $this->app->router->get('api/whatever', ['middleware' => 'auth:api', function () {
             return 'YoYo!';
@@ -63,7 +63,7 @@ class AuthenticationTest extends AbstractTestCase
     public function attempting_event_gets_fired_with_correct_credentials_with_auth_middleware()
     {
         $user = factory(User::class)->create([
-            'password' => bcrypt('123456'),
+            'password' => password_hash('123456'),
         ]);
         $this->app->router->get('api/whatever', ['middleware' => 'auth:api', function () {
             return 'YoYo!';
@@ -81,7 +81,7 @@ class AuthenticationTest extends AbstractTestCase
     public function login_event_not_fired_with_correct_credentials_with_auth_middleware()
     {
         $user = factory(User::class)->create([
-            'password' => bcrypt('123456'),
+            'password' => password_hash('123456'),
         ]);
         $this->app->router->get('api/whatever', ['middleware' => 'auth:api', function () {
             return 'YoYo!';
@@ -99,7 +99,7 @@ class AuthenticationTest extends AbstractTestCase
     public function basic_method_fires_attempting_event_with_valid_credentials()
     {
         $user = factory(User::class)->create([
-            'password' => bcrypt('123456'),
+            'password' => password_hash('123456'),
         ]);
 
         $this->app->router->get('api/whatever', function () {
@@ -133,7 +133,7 @@ class AuthenticationTest extends AbstractTestCase
     public function basic_method_fires_login_event_with_valid_credentials()
     {
         $user = factory(User::class)->create([
-            'password' => bcrypt('123456'),
+            'password' => password_hash('123456'),
         ]);
 
         $this->app->router->get('api/whatever', function () {
@@ -167,7 +167,7 @@ class AuthenticationTest extends AbstractTestCase
     public function onceBasic_method_does_not_fire_login_event_with_valid_credentials()
     {
         $user = factory(User::class)->create([
-            'password' => bcrypt('123456'),
+            'password' => password_hash('123456'),
         ]);
 
         $this->app->router->get('api/whatever', function () {

--- a/tests/database/factories/ModelFactory.php
+++ b/tests/database/factories/ModelFactory.php
@@ -10,6 +10,6 @@
 $factory->define(User::class, function (Faker\Generator $faker) {
     return [
         'email' => $faker->safeEmail,
-        'password' => bcrypt($faker->password),
+        'password' => password_hash($faker->password),
     ];
 });


### PR DESCRIPTION
Fix failing tests 

Laravel 5.5 required php >= 7.0, so you can't test it in php 5.6 or hhvm